### PR TITLE
Allow static FPF error callbacks via xml config

### DIFF
--- a/src/filter/AgaviFormPopulationFilter.class.php
+++ b/src/filter/AgaviFormPopulationFilter.class.php
@@ -764,7 +764,20 @@ class AgaviFormPopulationFilter extends AgaviFilter implements AgaviIGlobalFilte
 			$errorElements = array();
 
 			foreach($errors as $error) {
-				if(is_string($errorMarkup)) {
+				if(is_callable($errorMarkup)) {
+					// it's a callback we can use to get a DOMElement or an XML/HTML string (for convenience
+					// and because it is impossible to provide multiple sibling elements via a DOMElement)
+					// we give it the element as the first, the error message as the second (for BC reasons)
+					// and the error object as the third argument
+					$errorElement = call_user_func($errorMarkup, $element, $error->getMessage(), $error);
+					if(is_string($errorElement)) {
+						$errorElementHtml = $errorElement;
+						$errorElement = $this->doc->createDocumentFragment();
+						$errorElement->appendXML($errorElementHtml);
+					} else {
+						$this->doc->importNode($errorElement, true);
+					}
+				} elseif(is_string($errorMarkup)) {
 					// it's a string with the HTML to insert
 					// %s is the placeholder in the HTML for the error message
 					$errorElement = $this->doc->createDocumentFragment();
@@ -778,19 +791,6 @@ class AgaviFormPopulationFilter extends AgaviFilter implements AgaviIGlobalFilte
 							)
 						)
 					);
-				} elseif(is_callable($errorMarkup)) {
-					// it's a callback we can use to get a DOMElement or an XML/HTML string (for convenience
-					// and because it is impossible to provide multiple sibling elements via a DOMElement)
-					// we give it the element as the first, the error message as the second (for BC reasons)
-					// and the error object as the third argument
-					$errorElement = call_user_func($errorMarkup, $element, $error->getMessage(), $error);
-					if(is_string($errorElement)) {
-						$errorElementHtml = $errorElement;
-						$errorElement = $this->doc->createDocumentFragment();
-						$errorElement->appendXML($errorElementHtml);
-					} else {
-						$this->doc->importNode($errorElement, true);
-					}
 				} else {
 					throw new AgaviException('Form Population Filter was unable to insert an error message into the document using the XPath expression "' . $xpathExpression . '" because the element information could not be evaluated as an XML/HTML fragment or as a PHP callback.');
 				}
@@ -809,7 +809,20 @@ class AgaviFormPopulationFilter extends AgaviFilter implements AgaviIGlobalFilte
 				}
 
 				// create the container element and replace the errors placeholder in the container
-				if(is_string($errorContainer)) {
+				if(is_callable($errorContainer)) {
+					// it's a callback we can use to get a DOMElement or an XML/HTML string (for convenience
+					// and because it is impossible to provide multiple sibling elements via a DOMElement)
+					// we give it the element as the first, the error messages array(!) as the second (for BC reasons)
+					// and the array of all error objects as the third argument
+					$containerElement = call_user_func($errorContainer, $element, $errorStrings, $errors);
+					if(is_string($containerElement)) {
+						$containerElementHtml = $containerElement;
+						$containerElement = $this->doc->createDocumentFragment();
+						$containerElement->appendXML($containerElementHtml);
+					} else {
+						$this->doc->importNode($containerElement, true);
+					}
+				} elseif(is_string($errorContainer)) {
 					// it's a string with the HTML to insert
 					// %s is the placeholder in the HTML for the error message
 					$containerElement = $this->doc->createDocumentFragment();
@@ -823,19 +836,6 @@ class AgaviFormPopulationFilter extends AgaviFilter implements AgaviIGlobalFilte
 							)
 						)
 					);
-				} elseif(is_callable($errorContainer)) {
-					// it's a callback we can use to get a DOMElement or an XML/HTML string (for convenience
-					// and because it is impossible to provide multiple sibling elements via a DOMElement)
-					// we give it the element as the first, the error messages array(!) as the second (for BC reasons)
-					// and the array of all error objects as the third argument
-					$containerElement = call_user_func($errorContainer, $element, $errorStrings, $errors);
-					if(is_string($containerElement)) {
-						$containerElementHtml = $containerElement;
-						$containerElement = $this->doc->createDocumentFragment();
-						$containerElement->appendXML($containerElementHtml);
-					} else {
-						$this->doc->importNode($containerElement, true);
-					}
 				} else {
 					throw new AgaviException('Form Population Filter was unable to insert an error message container into the document using the XPath expression "' . $xpathExpression . '" because the element information could not be evaluated as an XML/HTML fragment or as a PHP callback.');
 				}


### PR DESCRIPTION
The change allows the usage of error callbacks in the FormPopulationFilter
via the 'markup' and 'container' parameters. This means providing any
callable parameter value (like the string 'My\Custom\Foo::renderError') via
global filters xml file or dynamic parameter setting later on will lead to
the FPF using that callable for error rendering. refs #1528
